### PR TITLE
[Phase 2] Add an icon besides percentile that pops up a modal for more information 

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -1,10 +1,8 @@
 <template lang="pug">
 #app
   loading-overlay.overlay-loader(
-    v-cloak,
-    v-bind:active.sync="isLoadingOverlayEnabled",
-    v-bind:opacity='loadingOverlayOpacity',
-    v-bind:is-full-page="true"
+    v-bind:active='isLoadingOverlayEnabled',
+    v-bind:opacity='loadingOverlayOpacity'
   )
     template(v-slot:default)
       i.overlay-loading-icon.fa.fa-spinner.fa-spin()
@@ -119,7 +117,9 @@ const app = {
       this.activateTab('authorship');
     },
     '$store.state.loadingOverlayCount': function () {
-      this.isLoadingOverlayEnabled = this.$store.state.loadingOverlayCount > 0;
+      this.$nextTick(() => {
+        this.isLoadingOverlayEnabled = this.$store.state.loadingOverlayCount > 0;
+      });
     },
   },
   methods: {

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 #app
   loading-overlay.overlay-loader(
-    v-bind:active='$store.state.loadingOverlayCount > 0',
+    v-bind:active='loadingOverlayCount > 0',
     v-bind:opacity='loadingOverlayOpacity'
   )
     template(v-slot:default)
@@ -290,7 +290,7 @@ const app = {
   },
 
   computed: {
-    ...mapState(['loadingOverlayMessage', 'isTabActive']),
+    ...mapState(['loadingOverlayCount', 'loadingOverlayMessage', 'isTabActive']),
   },
 
   components: {

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 #app
   loading-overlay.overlay-loader(
-    v-bind:active='isLoadingOverlayEnabled',
+    v-bind:active='$store.state.loadingOverlayCount > 0',
     v-bind:opacity='loadingOverlayOpacity'
   )
     template(v-slot:default)
@@ -97,7 +97,6 @@ const app = {
       users: [],
       userUpdated: false,
 
-      isLoadingOverlayEnabled: false,
       loadingOverlayOpacity: 1,
 
       tabType: 'empty',
@@ -115,11 +114,6 @@ const app = {
     },
     '$store.state.tabAuthorshipInfo': function () {
       this.activateTab('authorship');
-    },
-    '$store.state.loadingOverlayCount': function () {
-      this.$nextTick(() => {
-        this.isLoadingOverlayEnabled = this.$store.state.loadingOverlayCount > 0;
-      });
     },
   },
   methods: {

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -142,6 +142,7 @@ const app = {
       this.$store.commit('incrementLoadingOverlayCount', 1);
       this.$store.commit('updateLoadingOverlayMessage', loadingResourcesMessage);
       this.userUpdated = false;
+      await window.browserRerender();
       try {
         const {
           creationDate,

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -139,10 +139,9 @@ const app = {
     },
 
     async updateReportView() {
-      this.$store.commit('incrementLoadingOverlayCount', 1);
       this.$store.commit('updateLoadingOverlayMessage', loadingResourcesMessage);
       this.userUpdated = false;
-      await window.browserRerender();
+      await this.$store.dispatch('incrementLoadingOverlayCountForceReload', 1);
       try {
         const {
           creationDate,

--- a/frontend/src/components/v-modal.vue
+++ b/frontend/src/components/v-modal.vue
@@ -1,0 +1,92 @@
+<template lang="pug">
+transition(name='modal')
+  .modal-mask(v-if='show')
+    .modal-wrapper
+      .modal-container
+        .modal-header
+          h2  What does this number mean?
+        .modal-body
+          | This number means that the selected group,
+          | when sorted by contribution in {{ contributionOrder }} order,
+          | belongs to the top {{ percentile }} % of the whole cohort.
+        .modal-footer
+          button.modal-default-button(@click="$emit('close')")
+            | OK
+</template>
+
+<script>
+export default {
+  props: ['show', 'percentile', 'sortGroupSelection'],
+  computed: {
+    contributionOrder() {
+      return this.sortGroupSelection === 'totalCommits dsc' ? 'descending' : 'ascending';
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.modal-mask {
+  background-color: rgba(0, 0, 0, .5);
+  display: table;
+  height: 100%;
+  left: 0;
+  position: fixed;
+  top: 0;
+  transition: opacity .3s ease;
+  width: 100%;
+  z-index: 9998;
+}
+
+.modal-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.modal-container {
+  background-color: #fff;
+  border: 2px solid #006600;
+  border-radius: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
+  height: 200px;
+  margin: 0 auto;
+  padding: 20px 30px;
+  transition: all .3s ease;
+  width: 325px;
+}
+
+.modal-header {
+  margin-top: 0;
+}
+
+.modal-body {
+  margin: 20px 0;
+}
+
+.modal-default-button {
+  float: right;
+}
+
+/*
+ * The following styles are auto-applied to elements with
+ * transition="modal" when their visibility is toggled
+ * by Vue.js.
+ *
+ * You can easily play with the modal transition by editing
+ * these styles.
+ */
+
+.modal-enter-from {
+  opacity: 0;
+}
+
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-from .modal-container,
+.modal-leave-to .modal-container {
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
+}
+</style>

--- a/frontend/src/components/v-summary-charts.vue
+++ b/frontend/src/components/v-summary-charts.vue
@@ -74,7 +74,14 @@
             span.tooltip-text Click to view breakdown of commits
       .summary-chart__title--percentile(
           v-if="sortGroupSelection.includes('totalCommits')"
-        ) {{ getPercentile(i) }} %
+        ) {{ getPercentile(i) }} %&nbsp
+        font-awesome-icon.icon-button(:icon="['fas', 'circle-question']", @click="whichModalOpened = i + 1")
+        Teleport(to="body")
+          v-modal(
+            :show="whichModalOpened === i + 1 && filterGroupSelection !== 'groupByNone'",
+            @close="whichModalOpened = 0",
+            :percentile="getPercentile(i)",
+            :sort-group-selection = "sortGroupSelection")
     .summary-charts__fileType--breakdown(v-if="filterBreakdown")
       template(v-if="filterGroupSelection !== 'groupByNone'")
         .summary-charts__fileType--breakdown__legend(
@@ -135,7 +142,14 @@
             span.tooltip-text Click to view breakdown of commits
         .summary-chart__title--percentile(
           v-if="filterGroupSelection === 'groupByNone' && sortGroupSelection.includes('totalCommits')"
-        ) {{ getPercentile(j) }} %
+        ) {{ getPercentile(j) }} %&nbsp
+          font-awesome-icon.icon-button(:icon="['fas', 'circle-question']", @click="whichModalOpened = j + 1")
+          Teleport(to="body")
+            v-modal(
+              :show="whichModalOpened === j + 1 && filterGroupSelection === 'groupByNone'",
+              @close="whichModalOpened = 0",
+              :percentile="getPercentile(j)",
+              :sort-group-selection = "sortGroupSelection")
 
       .summary-chart__ramp(
         v-on:click="openTabZoomSubrange(user, $event, isGroupMerged(getGroupName(repo)))"
@@ -178,12 +192,14 @@
 <script>
 import { mapState } from 'vuex';
 
+import vModal from './v-modal.vue';
 import vRamp from './v-ramp.vue';
 
 export default {
   name: 'v-summary-charts',
   components: {
     vRamp,
+    vModal,
   },
   props: ['checkedFileTypes', 'filtered', 'avgContributionSize', 'filterBreakdown',
       'filterGroupSelection', 'filterTimeFrame', 'filterSinceDate', 'filterUntilDate', 'isMergeGroup',
@@ -195,6 +211,7 @@ export default {
       activeUser: null,
       activeTabType: null,
       isTabOnMergedGroup: false,
+      whichModalOpened: 0,
     };
   },
 

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -45,4 +45,15 @@ export default createStore({
       window.encodeHash();
     },
   },
+  actions: {
+    // Actions are called with dispatch
+
+    async incrementLoadingOverlayCountForceReload({ commit }, increment) {
+      commit('incrementLoadingOverlayCount', increment);
+      await new Promise(window.requestAnimationFrame);
+      await new Promise(window.requestAnimationFrame);
+      // Needed as browsers render lazily by default
+      // https://stackoverflow.com/a/44146560
+    },
+  },
 });

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -14,17 +14,6 @@ window.REPORT_ZIP = null;
 const HASH_ANCHOR = '?';
 const REPORT_DIR = '.';
 
-function requestAnimationFramePromise() {
-  return new Promise(requestAnimationFrame);
-}
-
-window.browserRerender = async function browserRerender() {
-  // Needed as browsers render lazily by default
-  // https://stackoverflow.com/a/44146560
-  await requestAnimationFramePromise();
-  await requestAnimationFramePromise();
-};
-
 window.deactivateAllOverlays = function deactivateAllOverlays() {
   document.querySelectorAll('.summary-chart__ramp .overlay')
       .forEach((x) => {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -14,6 +14,17 @@ window.REPORT_ZIP = null;
 const HASH_ANCHOR = '?';
 const REPORT_DIR = '.';
 
+function requestAnimationFramePromise() {
+  return new Promise(requestAnimationFrame);
+}
+
+window.browserRerender = async function browserRerender() {
+  // Needed as browsers render lazily by default
+  // https://stackoverflow.com/a/44146560
+  await requestAnimationFramePromise();
+  await requestAnimationFramePromise();
+};
+
 window.deactivateAllOverlays = function deactivateAllOverlays() {
   document.querySelectorAll('.summary-chart__ramp .overlay')
       .forEach((x) => {

--- a/frontend/src/utils/load-font-awesome-icons.js
+++ b/frontend/src/utils/load-font-awesome-icons.js
@@ -1,7 +1,7 @@
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
   faCaretDown, faCaretRight, faChevronCircleDown, faChevronCircleUp,
-  faChevronDown, faChevronUp, faCircle, faCode,
+  faChevronDown, faChevronUp, faCircle, faCircleQuestion, faCode,
   faEllipsisH, faExclamation, faHistory, faListUl,
   faPlusCircle, faSpinner, faTags, faUser, faUserEdit,
   faDatabase,
@@ -17,7 +17,7 @@ library.add(faCaretRight);
 library.add(faExclamation);
 
 // v-summary-charts
-library.add(faChevronUp, faChevronDown, faDatabase, faUser, faCode, faListUl, faCircle);
+library.add(faChevronUp, faChevronDown, faCircleQuestion, faDatabase, faUser, faCode, faListUl, faCircle);
 
 // v-zoom
 library.add(faTags, faEllipsisH);

--- a/frontend/src/views/v-authorship.vue
+++ b/frontend/src/views/v-authorship.vue
@@ -536,8 +536,7 @@ export default {
     },
 
     async updateSelectedFiles(setIsLoaded = false) {
-      this.$store.commit('incrementLoadingOverlayCount', 1);
-      await window.browserRerender();
+      await this.$store.dispatch('incrementLoadingOverlayCountForceReload', 1);
       this.selectedFiles = this.files.filter(
           (file) => ((this.selectedFileTypes.includes(file.fileType) && !file.isBinary && !file.isIgnored)
           || (file.isBinary && this.isBinaryFilesChecked) || (file.isIgnored && this.isIgnoredFilesChecked))

--- a/frontend/src/views/v-authorship.vue
+++ b/frontend/src/views/v-authorship.vue
@@ -535,20 +535,19 @@ export default {
       window.encodeHash();
     },
 
-    updateSelectedFiles(setIsLoaded = false) {
+    async updateSelectedFiles(setIsLoaded = false) {
       this.$store.commit('incrementLoadingOverlayCount', 1);
-      setTimeout(() => {
-        this.selectedFiles = this.files.filter(
-            (file) => ((this.selectedFileTypes.includes(file.fileType) && !file.isBinary && !file.isIgnored)
-            || (file.isBinary && this.isBinaryFilesChecked) || (file.isIgnored && this.isIgnoredFilesChecked))
-            && minimatch(file.path, this.searchBarValue || '*', { matchBase: true, dot: true }),
-        )
-            .sort(this.sortingFunction);
-        if (setIsLoaded) {
-          this.isLoaded = true;
-        }
-        this.$store.commit('incrementLoadingOverlayCount', -1);
-      });
+      await window.browserRerender();
+      this.selectedFiles = this.files.filter(
+          (file) => ((this.selectedFileTypes.includes(file.fileType) && !file.isBinary && !file.isIgnored)
+          || (file.isBinary && this.isBinaryFilesChecked) || (file.isIgnored && this.isIgnoredFilesChecked))
+          && minimatch(file.path, this.searchBarValue || '*', { matchBase: true, dot: true }),
+      )
+          .sort(this.sortingFunction);
+      if (setIsLoaded) {
+        this.isLoaded = true;
+      }
+      this.$store.commit('incrementLoadingOverlayCount', -1);
     },
 
     indicateSearchBar() {

--- a/frontend/src/views/v-summary.vue
+++ b/frontend/src/views/v-summary.vue
@@ -180,7 +180,7 @@ export default {
       const { allGroupsMerged } = this;
 
       this.$store.commit('incrementLoadingOverlayCount', 1);
-      setTimeout(() => {
+      window.browserRerender.then(() => {
         this.getFilteredRepos();
         this.updateMergedGroup(allGroupsMerged);
         this.$store.commit('incrementLoadingOverlayCount', -1);
@@ -407,17 +407,15 @@ export default {
       this.getFiltered();
     },
 
-    getFiltered() {
+    async getFiltered() {
       this.setSummaryHash();
       window.deactivateAllOverlays();
 
       this.$store.commit('incrementLoadingOverlayCount', 1);
-      // Use setTimeout() to force this.filtered to update only after loading screen is displayed.
-      setTimeout(() => {
-        this.getFilteredRepos();
-        this.getMergedRepos();
-        this.$store.commit('incrementLoadingOverlayCount', -1);
-      });
+      await window.browserRerender();
+      this.getFilteredRepos();
+      this.getMergedRepos();
+      this.$store.commit('incrementLoadingOverlayCount', -1);
     },
 
     getFilteredRepos() {

--- a/frontend/src/views/v-summary.vue
+++ b/frontend/src/views/v-summary.vue
@@ -179,8 +179,7 @@ export default {
       }
       const { allGroupsMerged } = this;
 
-      this.$store.commit('incrementLoadingOverlayCount', 1);
-      window.browserRerender().then(() => {
+      this.$store.dispatch('incrementLoadingOverlayCountForceReload', 1).then(() => {
         this.getFilteredRepos();
         this.updateMergedGroup(allGroupsMerged);
         this.$store.commit('incrementLoadingOverlayCount', -1);
@@ -411,8 +410,7 @@ export default {
       this.setSummaryHash();
       window.deactivateAllOverlays();
 
-      this.$store.commit('incrementLoadingOverlayCount', 1);
-      await window.browserRerender();
+      await this.$store.dispatch('incrementLoadingOverlayCountForceReload', 1);
       this.getFilteredRepos();
       this.getMergedRepos();
       this.$store.commit('incrementLoadingOverlayCount', -1);

--- a/frontend/src/views/v-summary.vue
+++ b/frontend/src/views/v-summary.vue
@@ -180,7 +180,7 @@ export default {
       const { allGroupsMerged } = this;
 
       this.$store.commit('incrementLoadingOverlayCount', 1);
-      window.browserRerender.then(() => {
+      window.browserRerender().then(() => {
         this.getFilteredRepos();
         this.updateMergedGroup(allGroupsMerged);
         this.$store.commit('incrementLoadingOverlayCount', -1);


### PR DESCRIPTION
## Proposed commit message
```
The percentile shown on the right when the groups are sorted by contribution is confusing 
for people who are new to seeing the report, as no explanations on this number are given.

Let’s add an icon that, when the user clicks on it, 
displays a modal so that the user knows the meaning this number in detail.

A modal is a helpful visualisation that does not clutter the screen of the report 
that is already contained with massive amounts of information.
```

## Other information
When group by set to None:
<img width="701" alt="image" src="https://user-images.githubusercontent.com/60286063/174086822-c7aeddc8-3bcd-4ae9-9adc-40795f0594a8.png">

When group by set to Repo/Branch or Author:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/60286063/174086910-9144b9c6-f608-4b8b-87e2-db4f30926ef2.png">

When clicking the help icon, modal pops up:
<img width="517" alt="image" src="https://user-images.githubusercontent.com/60286063/174087057-1fcf69df-a419-4e5c-99f0-6da410841a76.png">

